### PR TITLE
Fixed "time.format" is deprecated spam

### DIFF
--- a/src/scales/scale.realtime.js
+++ b/src/scales/scale.realtime.js
@@ -312,7 +312,6 @@ var defaultConfig = {
 	adapters: {},
 	time: {
 		parser: false, // false == a pattern string from http://momentjs.com/docs/#/parsing/string-format/ or a custom callback that converts its argument to a moment
-		format: false, // DEPRECATED false == date objects, moment object, callback or a pattern string from http://momentjs.com/docs/#/parsing/string-format/
 		unit: false, // false == automatic or override with week, month, year, etc.
 		round: false, // none, or override with week, month, year, etc.
 		displayFormat: false, // DEPRECATED


### PR DESCRIPTION
The format option being set causes spam in the latest version of chartjs.

![image](https://user-images.githubusercontent.com/13504878/69116316-d839be80-0adb-11ea-9510-5bb4c7a0bf89.png)

This removes the deprecated default option.