### PR TITLE
fix: add 'chart.js' in react example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -371,7 +371,7 @@
           <div class="terminal">
             <div class="header"></div>
             <div class="shell">
-              <p><span class="prompt">$</span>npm install react-chartjs-2 chartjs-plugin-streaming --save</p>
+              <p><span class="prompt">$</span>npm install chart.js react-chartjs-2 chartjs-plugin-streaming --save</p>
             </div>
           </div>
         </li>


### PR DESCRIPTION
Fixes `Module not found: Can't resolve 'chart.js'` error, described in #97 

Checks should be made on other config setup.